### PR TITLE
Parse numbers in Account entity

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,16 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Stream = exports.Client = void 0;
 var client_1 = require("./lib/client");
-Object.defineProperty(exports, "Client", {
-  enumerable: true,
-  get: function () {
-    return client_1.Client;
-  },
-});
+Object.defineProperty(exports, "Client", { enumerable: true, get: function () { return client_1.Client; } });
 var stream_1 = require("./lib/stream");
-Object.defineProperty(exports, "Stream", {
-  enumerable: true,
-  get: function () {
-    return stream_1.Stream;
-  },
-});
+Object.defineProperty(exports, "Stream", { enumerable: true, get: function () { return stream_1.Stream; } });

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -1,284 +1,156 @@
 "use strict";
-var __importDefault =
-  (this && this.__importDefault) ||
-  function (mod) {
-    return mod && mod.__esModule ? mod : { default: mod };
-  };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Client = void 0;
 const node_fetch_1 = __importDefault(require("node-fetch"));
 const http_method_enum_1 = __importDefault(require("http-method-enum"));
 const qs_1 = __importDefault(require("qs"));
+const parser_1 = require("./parser");
 const urls_1 = __importDefault(require("./urls"));
 const limiter_1 = require("limiter");
 class Client {
-  constructor(options) {
-    this.options = options;
-    this.limiter = new limiter_1.RateLimiter(199, "minute");
-  }
-  async isAuthenticated() {
-    try {
-      await this.getAccount();
-      return true;
-    } catch {
-      throw new Error("not authenticated");
+    constructor(options) {
+        this.options = options;
+        this.limiter = new limiter_1.RateLimiter(199, 'minute');
+        this.parser = new parser_1.Parser();
     }
-  }
-  getAccount() {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      "account"
-    );
-  }
-  getOrder(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `orders/${
-        params.order_id || params.client_order_id
-      }?${qs_1.default.stringify({
-        nested: params.nested,
-      })}`
-    );
-  }
-  getOrders(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `orders?${qs_1.default.stringify(params)}`
-    );
-  }
-  placeOrder(params) {
-    return this.request(
-      http_method_enum_1.default.POST,
-      urls_1.default.rest.account,
-      `orders`,
-      params
-    );
-  }
-  replaceOrder(params) {
-    return this.request(
-      http_method_enum_1.default.PATCH,
-      urls_1.default.rest.account,
-      `orders/${params.order_id}`,
-      params
-    );
-  }
-  cancelOrder(params) {
-    return this.request(
-      http_method_enum_1.default.DELETE,
-      urls_1.default.rest.account,
-      `orders/${params.order_id}`
-    );
-  }
-  cancelOrders() {
-    return this.request(
-      http_method_enum_1.default.DELETE,
-      urls_1.default.rest.account,
-      `orders`
-    );
-  }
-  getPosition(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `positions/${params.symbol}`
-    );
-  }
-  getPositions() {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `positions`
-    );
-  }
-  closePosition(params) {
-    return this.request(
-      http_method_enum_1.default.DELETE,
-      urls_1.default.rest.account,
-      `positions/${params.symbol}`
-    );
-  }
-  closePositions() {
-    return this.request(
-      http_method_enum_1.default.DELETE,
-      urls_1.default.rest.account,
-      `positions`
-    );
-  }
-  getAsset(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `assets/${params.asset_id_or_symbol}`
-    );
-  }
-  getAssets(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `assets?${qs_1.default.stringify(params)}`
-    );
-  }
-  getWatchlist(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `watchlists/${params.uuid}`
-    );
-  }
-  getWatchlists() {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `watchlists`
-    );
-  }
-  createWatchlist(params) {
-    return this.request(
-      http_method_enum_1.default.POST,
-      urls_1.default.rest.account,
-      `watchlists`,
-      params
-    );
-  }
-  updateWatchlist(params) {
-    return this.request(
-      http_method_enum_1.default.PUT,
-      urls_1.default.rest.account,
-      `watchlists/${params.uuid}`,
-      params
-    );
-  }
-  addToWatchlist(params) {
-    return this.request(
-      http_method_enum_1.default.POST,
-      urls_1.default.rest.account,
-      `watchlists/${params.uuid}`,
-      params
-    );
-  }
-  removeFromWatchlist(params) {
-    return this.request(
-      http_method_enum_1.default.DELETE,
-      urls_1.default.rest.account,
-      `watchlists/${params.uuid}/${params.symbol}`
-    );
-  }
-  deleteWatchlist(params) {
-    return this.request(
-      http_method_enum_1.default.DELETE,
-      urls_1.default.rest.account,
-      `watchlists/${params.uuid}`
-    );
-  }
-  getCalendar(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `calendar?${qs_1.default.stringify(params)}`
-    );
-  }
-  getClock() {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `clock`
-    );
-  }
-  getAccountConfigurations() {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `account/configurations`
-    );
-  }
-  updateAccountConfigurations(params) {
-    return this.request(
-      http_method_enum_1.default.PATCH,
-      urls_1.default.rest.account,
-      `account/configurations`,
-      params
-    );
-  }
-  getAccountActivities(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `account/activities/${params.activity_type}?${qs_1.default.stringify(
-        params
-      )}`
-    );
-  }
-  getPortfolioHistory(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.account,
-      `account/portfolio/history?${qs_1.default.stringify(params)}`
-    );
-  }
-  getBars(params) {
-    var transformed = {};
-    // join the symbols into a comma-delimited string
-    transformed = params;
-    transformed["symbols"] = params.symbols.join(",");
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.market_data,
-      `bars/${params.timeframe}?${qs_1.default.stringify(params)}`
-    );
-  }
-  getLastTrade(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.market_data,
-      `last/stocks/${params.symbol}`
-    );
-  }
-  getLastQuote(params) {
-    return this.request(
-      http_method_enum_1.default.GET,
-      urls_1.default.rest.market_data,
-      `last_quote/stocks/${params.symbol}`
-    );
-  }
-  request(method, url, endpoint, data) {
-    // modify the base url if paper is true
-    if (this.options.paper && url == urls_1.default.rest.account) {
-      url = urls_1.default.rest.account.replace("api.", "paper-api.");
-    }
-    // convert any dates to ISO 8601 for Alpaca
-    if (data) {
-      for (let [key, value] of Object.entries(data)) {
-        if (value instanceof Date) {
-          data[key] = value.toISOString();
+    async isAuthenticated() {
+        try {
+            await this.getAccount();
+            return true;
         }
-      }
+        catch {
+            throw new Error('not authenticated');
+        }
     }
-    return new Promise(async (resolve, reject) => {
-      // do rate limiting
-      if (this.options.rate_limit) {
-        await new Promise((resolve) => this.limiter.removeTokens(1, resolve));
-      }
-      await node_fetch_1
-        .default(`${url}/${endpoint}`, {
-          method: method,
-          headers: {
-            "APCA-API-KEY-ID": this.options.credentials.key,
-            "APCA-API-SECRET-KEY": this.options.credentials.secret,
-          },
-          body: JSON.stringify(data),
-        })
-        .then(
-          // if json parse fails we default to an empty object
-          async (response) => (await response.json().catch(() => false)) || {}
-        )
-        .then((json) =>
-          "code" in json && "message" in json ? reject(json) : resolve(json)
-        )
-        .catch(reject);
-    });
-  }
+    async getAccount() {
+        const rawAccount = await this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, 'account');
+        return this.parser.parseAccount(rawAccount);
+    }
+    getOrder(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `orders/${params.order_id || params.client_order_id}?${qs_1.default.stringify({
+            nested: params.nested,
+        })}`);
+    }
+    getOrders(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `orders?${qs_1.default.stringify(params)}`);
+    }
+    placeOrder(params) {
+        return this.request(http_method_enum_1.default.POST, urls_1.default.rest.account, `orders`, params);
+    }
+    replaceOrder(params) {
+        return this.request(http_method_enum_1.default.PATCH, urls_1.default.rest.account, `orders/${params.order_id}`, params);
+    }
+    cancelOrder(params) {
+        return this.request(http_method_enum_1.default.DELETE, urls_1.default.rest.account, `orders/${params.order_id}`);
+    }
+    cancelOrders() {
+        return this.request(http_method_enum_1.default.DELETE, urls_1.default.rest.account, `orders`);
+    }
+    getPosition(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `positions/${params.symbol}`);
+    }
+    getPositions() {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `positions`);
+    }
+    closePosition(params) {
+        return this.request(http_method_enum_1.default.DELETE, urls_1.default.rest.account, `positions/${params.symbol}`);
+    }
+    closePositions() {
+        return this.request(http_method_enum_1.default.DELETE, urls_1.default.rest.account, `positions`);
+    }
+    getAsset(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `assets/${params.asset_id_or_symbol}`);
+    }
+    getAssets(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `assets?${qs_1.default.stringify(params)}`);
+    }
+    getWatchlist(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `watchlists/${params.uuid}`);
+    }
+    getWatchlists() {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `watchlists`);
+    }
+    createWatchlist(params) {
+        return this.request(http_method_enum_1.default.POST, urls_1.default.rest.account, `watchlists`, params);
+    }
+    updateWatchlist(params) {
+        return this.request(http_method_enum_1.default.PUT, urls_1.default.rest.account, `watchlists/${params.uuid}`, params);
+    }
+    addToWatchlist(params) {
+        return this.request(http_method_enum_1.default.POST, urls_1.default.rest.account, `watchlists/${params.uuid}`, params);
+    }
+    removeFromWatchlist(params) {
+        return this.request(http_method_enum_1.default.DELETE, urls_1.default.rest.account, `watchlists/${params.uuid}/${params.symbol}`);
+    }
+    deleteWatchlist(params) {
+        return this.request(http_method_enum_1.default.DELETE, urls_1.default.rest.account, `watchlists/${params.uuid}`);
+    }
+    getCalendar(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `calendar?${qs_1.default.stringify(params)}`);
+    }
+    getClock() {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `clock`);
+    }
+    getAccountConfigurations() {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `account/configurations`);
+    }
+    updateAccountConfigurations(params) {
+        return this.request(http_method_enum_1.default.PATCH, urls_1.default.rest.account, `account/configurations`, params);
+    }
+    getAccountActivities(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `account/activities/${params.activity_type}?${qs_1.default.stringify(params)}`);
+    }
+    getPortfolioHistory(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.account, `account/portfolio/history?${qs_1.default.stringify(params)}`);
+    }
+    getBars(params) {
+        var transformed = {};
+        // join the symbols into a comma-delimited string
+        transformed = params;
+        transformed['symbols'] = params.symbols.join(',');
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.market_data, `bars/${params.timeframe}?${qs_1.default.stringify(params)}`);
+    }
+    getLastTrade(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.market_data, `last/stocks/${params.symbol}`);
+    }
+    getLastQuote(params) {
+        return this.request(http_method_enum_1.default.GET, urls_1.default.rest.market_data, `last_quote/stocks/${params.symbol}`);
+    }
+    request(method, url, endpoint, data) {
+        // modify the base url if paper is true
+        if (this.options.paper && url == urls_1.default.rest.account) {
+            url = urls_1.default.rest.account.replace('api.', 'paper-api.');
+        }
+        // convert any dates to ISO 8601 for Alpaca
+        if (data) {
+            for (let [key, value] of Object.entries(data)) {
+                if (value instanceof Date) {
+                    data[key] = value.toISOString();
+                }
+            }
+        }
+        return new Promise(async (resolve, reject) => {
+            // do rate limiting
+            if (this.options.rate_limit) {
+                await new Promise((resolve) => this.limiter.removeTokens(1, resolve));
+            }
+            await node_fetch_1.default(`${url}/${endpoint}`, {
+                method: method,
+                headers: {
+                    'APCA-API-KEY-ID': this.options.credentials.key,
+                    'APCA-API-SECRET-KEY': this.options.credentials.secret,
+                },
+                body: JSON.stringify(data),
+            })
+                .then(
+            // if json parse fails we default to an empty object
+            async (response) => (await response.json().catch(() => false)) || {})
+                .then((json) => 'code' in json && 'message' in json ? reject(json) : resolve(json))
+                .catch(reject);
+        });
+    }
 }
 exports.Client = Client;

--- a/dist/lib/parser.js
+++ b/dist/lib/parser.js
@@ -1,0 +1,32 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Parser = void 0;
+class Parser {
+    parseAccount(rawAccount) {
+        if (!rawAccount) {
+            return null;
+        }
+        return {
+            ...rawAccount,
+            buying_power: this.parseNumber(rawAccount.buying_power),
+            regt_buying_power: this.parseNumber(rawAccount.regt_buying_power),
+            daytrading_buying_power: this.parseNumber(rawAccount.daytrading_buying_power),
+            cash: this.parseNumber(rawAccount.cash),
+            portfolio_value: this.parseNumber(rawAccount.portfolio_value),
+            multiplier: this.parseNumber(rawAccount.multiplier),
+            equity: this.parseNumber(rawAccount.equity),
+            last_equity: this.parseNumber(rawAccount.last_equity),
+            long_market_value: this.parseNumber(rawAccount.long_market_value),
+            short_market_value: this.parseNumber(rawAccount.short_market_value),
+            initial_margin: this.parseNumber(rawAccount.initial_margin),
+            maintenance_margin: this.parseNumber(rawAccount.maintenance_margin),
+            last_maintenance_margin: this.parseNumber(rawAccount.last_maintenance_margin),
+            sma: this.parseNumber(rawAccount.sma),
+            status: rawAccount.status
+        };
+    }
+    parseNumber(numStr) {
+        return parseFloat(numStr);
+    }
+}
+exports.Parser = Parser;

--- a/dist/lib/stream.js
+++ b/dist/lib/stream.js
@@ -1,130 +1,118 @@
 "use strict";
-var __importDefault =
-  (this && this.__importDefault) ||
-  function (mod) {
-    return mod && mod.__esModule ? mod : { default: mod };
-  };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Stream = void 0;
 const ws_1 = __importDefault(require("ws"));
 const events_1 = require("events");
 const urls_1 = __importDefault(require("./urls"));
 class Stream extends events_1.EventEmitter {
-  constructor(params) {
-    // construct EventEmitter
-    super();
-    this.params = params;
-    this.subscriptions = [];
-    this.authenticated = false;
-    // assign the host we will connect to
-    switch (params.stream) {
-      case "account":
-        this.host = urls_1.default.websocket.account;
-        break;
-      case "market_data":
-        this.host = urls_1.default.websocket.market_data;
-        break;
-      default:
-        this.host = "unknown";
+    constructor(params) {
+        // construct EventEmitter
+        super();
+        this.params = params;
+        this.subscriptions = [];
+        this.authenticated = false;
+        // assign the host we will connect to
+        switch (params.stream) {
+            case 'account':
+                this.host = urls_1.default.websocket.account;
+                break;
+            case 'market_data':
+                this.host = urls_1.default.websocket.market_data;
+                break;
+            default:
+                this.host = 'unknown';
+        }
+        this.connection = new ws_1.default(this.host)
+            .once('open', () => {
+            // if we are not authenticated yet send a request now
+            if (!this.authenticated) {
+                this.connection.send(JSON.stringify({
+                    action: 'authenticate',
+                    data: {
+                        key_id: params.credentials.key,
+                        secret_key: params.credentials.secret,
+                    },
+                }));
+            }
+            // pass the open
+            this.emit('open', this);
+        })
+            // pass the close
+            .once('close', () => this.emit('close', this))
+            .on('message', (message) => {
+            // parse the incoming message
+            const object = JSON.parse(message.toString());
+            // if the message is an authorization response
+            if ('stream' in object && object.stream == 'authorization') {
+                if (object.data.status == 'authorized') {
+                    this.authenticated = true;
+                    this.emit('authenticated', this);
+                    console.log('Connected to the websocket.');
+                }
+                else {
+                    this.connection.close();
+                    throw new Error('There was an error in authorizing your websocket connection. Object received: ' +
+                        JSON.stringify(object, null, 2));
+                }
+            }
+            // pass the message
+            this.emit('message', object);
+            // emit based on the stream
+            if ('stream' in object) {
+                this.emit({
+                    trade_updates: 'trade_updates',
+                    account_updates: 'account_updates',
+                    T: 'trade',
+                    Q: 'quote',
+                    AM: 'aggregate_minute',
+                }[object.stream.split('.')[0]], object.data);
+            }
+        })
+            // pass the error
+            .on('error', (err) => this.emit('error', err));
     }
-    this.connection = new ws_1.default(this.host)
-      .once("open", () => {
-        // if we are not authenticated yet send a request now
+    send(message) {
+        // don't bother if we aren't authenticated yet
         if (!this.authenticated) {
-          this.connection.send(
-            JSON.stringify({
-              action: "authenticate",
-              data: {
-                key_id: params.credentials.key,
-                secret_key: params.credentials.secret,
-              },
-            })
-          );
+            throw new Error("You can't send a message until you are authenticated!");
         }
-        // pass the open
-        this.emit("open", this);
-      })
-      // pass the close
-      .once("close", () => this.emit("close", this))
-      .on("message", (message) => {
-        // parse the incoming message
-        const object = JSON.parse(message.toString());
-        // if the message is an authorization response
-        if ("stream" in object && object.stream == "authorization") {
-          if (object.data.status == "authorized") {
-            this.authenticated = true;
-            this.emit("authenticated", this);
-            console.log("Connected to the websocket.");
-          } else {
-            this.connection.close();
-            throw new Error(
-              "There was an error in authorizing your websocket connection. Object received: " +
-                JSON.stringify(object, null, 2)
-            );
-          }
+        // if the message is in object form, stringify it for the user
+        if (typeof message == 'object') {
+            message = JSON.stringify(message);
         }
-        // pass the message
-        this.emit("message", object);
-        // emit based on the stream
-        if ("stream" in object) {
-          this.emit(
-            {
-              trade_updates: "trade_updates",
-              account_updates: "account_updates",
-              T: "trade",
-              Q: "quote",
-              AM: "aggregate_minute",
-            }[object.stream.split(".")[0]],
-            object.data
-          );
+        // send it off
+        this.connection.send(message);
+        // chainable return
+        return this;
+    }
+    subscribe(channels) {
+        // add these channels internally
+        this.subscriptions.push(...channels);
+        // try to subscribe to them
+        return this.send(JSON.stringify({
+            action: 'listen',
+            data: {
+                streams: channels,
+            },
+        }));
+    }
+    unsubscribe(channels) {
+        // remove these channels internally
+        for (let i = 0, ln = this.subscriptions.length; i < ln; i++) {
+            if (channels.includes(this.subscriptions[i])) {
+                this.subscriptions.splice(i, 1);
+            }
         }
-      })
-      // pass the error
-      .on("error", (err) => this.emit("error", err));
-  }
-  send(message) {
-    // don't bother if we aren't authenticated yet
-    if (!this.authenticated) {
-      throw new Error("You can't send a message until you are authenticated!");
+        // try to unsubscribe from them
+        return this.send(JSON.stringify({
+            action: 'unlisten',
+            data: {
+                streams: channels,
+            },
+        }));
     }
-    // if the message is in object form, stringify it for the user
-    if (typeof message == "object") {
-      message = JSON.stringify(message);
-    }
-    // send it off
-    this.connection.send(message);
-    // chainable return
-    return this;
-  }
-  subscribe(channels) {
-    // add these channels internally
-    this.subscriptions.push(...channels);
-    // try to subscribe to them
-    return this.send(
-      JSON.stringify({
-        action: "listen",
-        data: {
-          streams: channels,
-        },
-      })
-    );
-  }
-  unsubscribe(channels) {
-    // remove these channels internally
-    for (let i = 0, ln = this.subscriptions.length; i < ln; i++) {
-      if (channels.includes(this.subscriptions[i])) {
-        this.subscriptions.splice(i, 1);
-      }
-    }
-    // try to unsubscribe from them
-    return this.send(
-      JSON.stringify({
-        action: "unlisten",
-        data: {
-          streams: channels,
-        },
-      })
-    );
-  }
 }
 exports.Stream = Stream;

--- a/dist/lib/urls.js
+++ b/dist/lib/urls.js
@@ -1,12 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = {
-  rest: {
-    account: "https://api.alpaca.markets/v2",
-    market_data: "https://data.alpaca.markets/v1",
-  },
-  websocket: {
-    account: "wss://api.alpaca.markets/stream",
-    market_data: "wss://data.alpaca.markets/stream",
-  },
+    rest: {
+        account: 'https://api.alpaca.markets/v2',
+        market_data: 'https://data.alpaca.markets/v1',
+    },
+    websocket: {
+        account: 'wss://api.alpaca.markets/stream',
+        market_data: 'wss://data.alpaca.markets/stream',
+    },
 };

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -3,7 +3,11 @@ export interface Credentials {
   secret: string
 }
 
-export interface Account {
+/**
+ * The account information with unparsed types, exactly as Alpaca provides it.
+ * We encourage you to use the Account interface, which has many of these fields parsed.
+ */
+export interface RawAccount {
   account_blocked: boolean
   account_number: string
   buying_power: string
@@ -29,6 +33,192 @@ export interface Account {
   status: string
   trade_suspended_by_user: boolean
   trading_blocked: boolean
+  transfers_blocked: boolean
+}
+
+/**
+ * The following are the possible account status values. Most likely, the account status
+ * is ACTIVE unless there is any problem. The account status may get in ACCOUNT_UPDATED
+ * when personal information is being updated from the dashboard, in which case you may
+ * not be allowed trading for a short period of time until the change is approved.
+ */
+export type AccountStatus =
+  /**
+   * The account is onboarding.
+   */
+  'ONBOARDING' |
+  /**
+   * The account application submission failed for some reason.
+   */
+  'SUBMISSION_FAILED' |
+  /**
+   * The account application has been submitted for review.
+   */
+  'SUBMITTED' |
+  /**
+   * The account information is being updated.
+   */
+  'ACCOUNT_UPDATED' |
+  /**
+   * The final account approval is pending.
+   */
+  'APPROVAL_PENDING' |
+  /**
+   * The account is active for trading.
+   */
+  'ACTIVE' |
+  /**
+   * The account application has been rejected.
+   */
+  'REJECTED'
+
+/**
+ * Information related to an Alpaca account, such as account status, funds, and various
+ * flags relevant to an account’s ability to trade.
+ */
+export interface Account {
+  /**
+   * If true, the account activity by user is prohibited.
+   */
+  account_blocked: boolean
+
+  /**
+   * Account number.
+   */
+  account_number: string
+
+  /**
+   * Current available $ buying power; If multiplier = 4, this is your daytrade buying
+   * power which is calculated as (last_equity - (last) maintenance_margin) * 4; If
+   * multiplier = 2, buying_power = max(equity – initial_margin,0) * 2; If multiplier = 1,
+   * buying_power = cash
+   */
+  buying_power: number
+
+  /**
+   * Cash balance
+   */
+  cash: number
+
+  /**
+   * Timestamp this account was created at
+   */
+  created_at: string
+
+  /**
+   * "USD"
+   */
+  currency: string
+
+  /**
+   * The current number of daytrades that have been made in the last 5 trading days
+   * (inclusive of today)
+   */
+  daytrade_count: number
+
+  /**
+   * Your buying power for day trades (continuously updated value)
+   */
+  daytrading_buying_power: number
+
+  /**
+   * Cash + long_market_value + short_market_value
+   */
+  equity: number
+
+  /**
+   * Account ID.
+   */
+  id: string
+
+  /**
+   * Reg T initial margin requirement (continuously updated value)
+   */
+  initial_margin: number
+
+  /**
+   * Equity as of previous trading day at 16:00:00 ET
+   */
+  last_equity: number
+
+  /**
+   * Your maintenance margin requirement on the previous trading day
+   */
+  last_maintenance_margin: number
+
+  /**
+   * Real-time MtM value of all long positions held in the account
+   */
+  long_market_value: number
+
+  /**
+   * Maintenance margin requirement (continuously updated value)
+   */
+  maintenance_margin: number
+
+  /**
+   * Buying power multiplier that represents account margin classification; valid values 1
+   * (standard limited margin account with 1x buying power), 2 (reg T margin account with
+   * 2x intraday and overnight buying power; this is the default for all non-PDT accounts
+   * with $2,000 or more equity), 4 (PDT account with 4x intraday buying power and 2x reg
+   * T overnight buying power)
+   */
+  multiplier: number
+
+  /**
+   * Whether or not the account has been flagged as a pattern day trader
+   */
+  pattern_day_trader: boolean
+
+  /**
+   * Total value of cash + holding positions (This field is deprecated. It is equivalent
+   * to the equity field.)
+   */
+  portfolio_value: number
+
+  /**
+   * Your buying power under Regulation T (your excess equity - equity minus margin
+   * value - times your margin multiplier)
+   */
+  regt_buying_power: number
+
+  /**
+   * Real-time MtM value of all short positions held in the account
+   */
+  short_market_value: number
+
+  /**
+   * Flag to denote whether or not the account is permitted to short
+   */
+  shorting_enabled: boolean
+
+  /**
+   * Value of special memorandum account (will be used at a later date to provide
+   * additional buying_power)
+   */
+  sma: number
+
+  /**
+   * The following are the possible account status values. Most likely, the account status
+   * is ACTIVE unless there is any problem. The account status may get in ACCOUNT_UPDATED
+   * when personal information is being updated from the dashboard, in which case you may
+   * not be allowed trading for a short period of time until the change is approved.
+   */
+  status: AccountStatus
+
+  /**
+   * User setting. If true, the account is not allowed to place orders.
+   */
+  trade_suspended_by_user: boolean
+
+  /**
+   * If true, the account is not allowed to place orders.
+   */
+  trading_blocked: boolean
+
+  /**
+   * If true, the account is not allowed to request money transfers.
+   */
   transfers_blocked: boolean
 }
 

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -1,0 +1,32 @@
+import { Account, RawAccount, AccountStatus } from './entities';
+
+export class Parser {
+  parseAccount(rawAccount: RawAccount): Account {
+    if (!rawAccount) {
+      return null
+    }
+
+    return {
+      ...rawAccount,
+      buying_power: this.parseNumber(rawAccount.buying_power),
+      regt_buying_power: this.parseNumber(rawAccount.regt_buying_power),
+      daytrading_buying_power: this.parseNumber(rawAccount.daytrading_buying_power),
+      cash: this.parseNumber(rawAccount.cash),
+      portfolio_value: this.parseNumber(rawAccount.portfolio_value),
+      multiplier: this.parseNumber(rawAccount.multiplier),
+      equity: this.parseNumber(rawAccount.equity),
+      last_equity: this.parseNumber(rawAccount.last_equity),
+      long_market_value: this.parseNumber(rawAccount.long_market_value),
+      short_market_value: this.parseNumber(rawAccount.short_market_value),
+      initial_margin: this.parseNumber(rawAccount.initial_margin),
+      maintenance_margin: this.parseNumber(rawAccount.maintenance_margin),
+      last_maintenance_margin: this.parseNumber(rawAccount.last_maintenance_margin),
+      sma: this.parseNumber(rawAccount.sma),
+      status: rawAccount.status as AccountStatus
+    }
+  }
+
+  private parseNumber(numStr: string): number {
+    return parseFloat(numStr)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@master-chief/alpaca",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "A TypeScript Node.js library for the https://alpaca.markets REST API and WebSocket streams.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -17,7 +17,8 @@
     "stock"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "npm run clean && tsc",
+    "clean": "rimraf dist types",
     "test": "npm run build && $(npm bin)/ava -v"
   },
   "author": "master-chief",
@@ -37,6 +38,7 @@
     "@types/node-fetch": "^2.5.7",
     "@types/qs": "^6.9.3",
     "@types/ws": "^7.2.4",
-    "ava": "^3.8.2"
+    "ava": "^3.8.2",
+    "rimraf": "3.0.2"
   }
 }

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -7,6 +7,7 @@ export declare class Client {
         rate_limit?: boolean;
     };
     private limiter;
+    private parser;
     constructor(options: {
         credentials: Credentials;
         paper?: boolean;

--- a/types/lib/entities.d.ts
+++ b/types/lib/entities.d.ts
@@ -2,7 +2,11 @@ export interface Credentials {
     key: string;
     secret: string;
 }
-export interface Account {
+/**
+ * The account information with unparsed types, exactly as Alpaca provides it.
+ * We encourage you to use the Account interface, which has many of these fields parsed.
+ */
+export interface RawAccount {
     account_blocked: boolean;
     account_number: string;
     buying_power: string;
@@ -28,6 +32,165 @@ export interface Account {
     status: string;
     trade_suspended_by_user: boolean;
     trading_blocked: boolean;
+    transfers_blocked: boolean;
+}
+/**
+ * The following are the possible account status values. Most likely, the account status
+ * is ACTIVE unless there is any problem. The account status may get in ACCOUNT_UPDATED
+ * when personal information is being updated from the dashboard, in which case you may
+ * not be allowed trading for a short period of time until the change is approved.
+ */
+export declare type AccountStatus = 
+/**
+ * The account is onboarding.
+ */
+'ONBOARDING' | 
+/**
+ * The account application submission failed for some reason.
+ */
+'SUBMISSION_FAILED' | 
+/**
+ * The account application has been submitted for review.
+ */
+'SUBMITTED' | 
+/**
+ * The account information is being updated.
+ */
+'ACCOUNT_UPDATED' | 
+/**
+ * The final account approval is pending.
+ */
+'APPROVAL_PENDING' | 
+/**
+ * The account is active for trading.
+ */
+'ACTIVE' | 
+/**
+ * The account application has been rejected.
+ */
+'REJECTED';
+/**
+ * Information related to an Alpaca account, such as account status, funds, and various
+ * flags relevant to an account’s ability to trade.
+ */
+export interface Account {
+    /**
+     * If true, the account activity by user is prohibited.
+     */
+    account_blocked: boolean;
+    /**
+     * Account number.
+     */
+    account_number: string;
+    /**
+     * Current available $ buying power; If multiplier = 4, this is your daytrade buying
+     * power which is calculated as (last_equity - (last) maintenance_margin) * 4; If
+     * multiplier = 2, buying_power = max(equity – initial_margin,0) * 2; If multiplier = 1,
+     * buying_power = cash
+     */
+    buying_power: number;
+    /**
+     * Cash balance
+     */
+    cash: number;
+    /**
+     * Timestamp this account was created at
+     */
+    created_at: string;
+    /**
+     * "USD"
+     */
+    currency: string;
+    /**
+     * The current number of daytrades that have been made in the last 5 trading days
+     * (inclusive of today)
+     */
+    daytrade_count: number;
+    /**
+     * Your buying power for day trades (continuously updated value)
+     */
+    daytrading_buying_power: number;
+    /**
+     * Cash + long_market_value + short_market_value
+     */
+    equity: number;
+    /**
+     * Account ID.
+     */
+    id: string;
+    /**
+     * Reg T initial margin requirement (continuously updated value)
+     */
+    initial_margin: number;
+    /**
+     * Equity as of previous trading day at 16:00:00 ET
+     */
+    last_equity: number;
+    /**
+     * Your maintenance margin requirement on the previous trading day
+     */
+    last_maintenance_margin: number;
+    /**
+     * Real-time MtM value of all long positions held in the account
+     */
+    long_market_value: number;
+    /**
+     * Maintenance margin requirement (continuously updated value)
+     */
+    maintenance_margin: number;
+    /**
+     * Buying power multiplier that represents account margin classification; valid values 1
+     * (standard limited margin account with 1x buying power), 2 (reg T margin account with
+     * 2x intraday and overnight buying power; this is the default for all non-PDT accounts
+     * with $2,000 or more equity), 4 (PDT account with 4x intraday buying power and 2x reg
+     * T overnight buying power)
+     */
+    multiplier: number;
+    /**
+     * Whether or not the account has been flagged as a pattern day trader
+     */
+    pattern_day_trader: boolean;
+    /**
+     * Total value of cash + holding positions (This field is deprecated. It is equivalent
+     * to the equity field.)
+     */
+    portfolio_value: number;
+    /**
+     * Your buying power under Regulation T (your excess equity - equity minus margin
+     * value - times your margin multiplier)
+     */
+    regt_buying_power: number;
+    /**
+     * Real-time MtM value of all short positions held in the account
+     */
+    short_market_value: number;
+    /**
+     * Flag to denote whether or not the account is permitted to short
+     */
+    shorting_enabled: boolean;
+    /**
+     * Value of special memorandum account (will be used at a later date to provide
+     * additional buying_power)
+     */
+    sma: number;
+    /**
+     * The following are the possible account status values. Most likely, the account status
+     * is ACTIVE unless there is any problem. The account status may get in ACCOUNT_UPDATED
+     * when personal information is being updated from the dashboard, in which case you may
+     * not be allowed trading for a short period of time until the change is approved.
+     */
+    status: AccountStatus;
+    /**
+     * User setting. If true, the account is not allowed to place orders.
+     */
+    trade_suspended_by_user: boolean;
+    /**
+     * If true, the account is not allowed to place orders.
+     */
+    trading_blocked: boolean;
+    /**
+     * If true, the account is not allowed to request money transfers.
+     */
     transfers_blocked: boolean;
 }
 export interface AccountConfigurations {

--- a/types/lib/parser.d.ts
+++ b/types/lib/parser.d.ts
@@ -1,0 +1,5 @@
+import { Account, RawAccount } from './entities';
+export declare class Parser {
+    parseAccount(rawAccount: RawAccount): Account;
+    private parseNumber;
+}


### PR DESCRIPTION
First step at Issue #9 -- just tackling the `Account` entity in this PR. The goal is to find an approach we like before moving on to the rest of the entities.

## Overview

The general approach is to split [the existing `Account` entity type](https://github.com/117/alpaca/blob/master/lib/entities.ts#L6-L33) into two types: `RawAccount` and `Account`.

* `RawAccount` represents the data in the same way it comes from the Alpaca API. Numbers, dates, and enums are all represented as strings.
* `Account` represents the data with certain fields parsed for convenience.
  * In this PR, I parse all numbers to `number` and I provide a type for the `status` enum
  * **I'm not parsing dates in this PR.** See more info on that in the questions section below.

Then we have a simple `Parser` class that is responsible for converting from `RawAccount` to `Account`. In the `Client`'s `getAccount()` method, we simply make the API request, then call the parser. That's pretty much it.

## Questions

#### Branch

I think you'll want to make a `2.x` branch that we can merge this (and future PRs) to correct? Once you do that, I can update this PR to go there rather than `master`.

#### Prettier thing

The Prettier build step is failing. It looks like maybe it can't handle this PR because it's coming from my fork? Do you know if that's expected? 

#### Tests

I wanted to write tests for the parser, but I couldn't get AVA up and running quickly without making a bunch of changes. I guess we'll add tests later?

#### Parsing Dates

I chose not to parse dates in this PR. I'm worried about timezones. As soon as you go from `string` to `Date`, you get a date that is in the timezone of whatever machine parsed it. This is a source of bugs. For example, you might have one machine hit the API and another machine process the data and those machines could be in different timezones.

We _could_ parse dates and inform users of this package to be careful with timezones, but I believe it's safer to leave them as ISO-8601 strings and let the user do the parsing themselves.

Thoughts?

#### General style

Feel free to nitpick on stuff in here as I get used to the project's style. I do feel like this project would benefit from some lint rules, although maybe that's a non-issue since there is the Prettier action thing.

## Manual testing

I npm linked my fork locally to my trading app. I hit the `getAccount()` method in the client and logged the output. The output matched my expectations.

<img width="349" alt="Screen Shot 2020-09-11 at 3 56 27 PM" src="https://user-images.githubusercontent.com/704472/92976486-d9abed00-f447-11ea-9653-1fdb6b7666f0.png">
