### PR TITLE
AlpacaStream support for ArrayBuffer formatted binary messages

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -109,6 +109,8 @@ export class AlpacaStream extends EventEmitter<string | symbol | any> {
 
       if (data instanceof Blob) {
         data = await event.data.text()
+      } else if (data instanceof ArrayBuffer) {
+        data = String.fromCharCode(...new Uint8Array(event.data))
       }
 
       let parsed = JSON.parse(data),


### PR DESCRIPTION
Hi there,

In a React Native project, I ran into a JSON.parse error on instantiating an AlpacaStream because (in this context) the default binary data type for WebSocket seems to be [ArrayBuffer rather than Blob](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/binaryType). This might be fixable by instead setting `this.connection.binaryType = 'blob';` right after instantiating the WebSocket, but I offer this addition for any use cases where ArrayBuffer might be needed.

For reference, the decoding of the ArrayBuffer was taken from [here](https://stackoverflow.com/questions/50198017/converting-arraybuffer-to-string-then-back-to-arraybuffer-using-textdecoder-text).