### PR TITLE
Remove file extension from imports to allow for multi-target builds

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,8 +3,8 @@ import Bottleneck from 'bottleneck'
 import qs from 'qs'
 import isofetch from 'isomorphic-unfetch'
 
-import urls from './urls.js'
-import parse from './parse.js'
+import urls from './urls'
+import parse from './parse'
 
 import {
   RawAccount,
@@ -32,7 +32,7 @@ import {
   LastQuote_v1,
   LastTrade_v1,
   Snapshot,
-} from './entities.js'
+} from './entities'
 
 import {
   GetOrder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-export { AlpacaClient } from './client.js'
-export { AlpacaStream } from './stream.js'
+export { AlpacaClient } from './client'
+export { AlpacaStream } from './stream'
 
-import { AlpacaClient } from './client.js'
-import { AlpacaStream } from './stream.js'
+import { AlpacaClient } from './client'
+import { AlpacaStream } from './stream'
 
 export default {
   AlpacaClient: AlpacaClient,

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,4 +1,4 @@
-import { OrderSide, OrderType, OrderTimeInForce } from './entities.js'
+import { OrderSide, OrderType, OrderTimeInForce } from './entities'
 
 export interface AddToWatchList {
   uuid: string

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -31,7 +31,7 @@ import {
   PageOfBars,
   Snapshot,
   RawSnapshot,
-} from './entities.js'
+} from './entities'
 
 function account(rawAccount: RawAccount): Account {
   if (!rawAccount) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,7 +1,7 @@
 import WebSocket from 'isomorphic-ws'
 import EventEmitter from 'eventemitter3'
 import isBlob from 'is-blob'
-import urls from './urls.js'
+import urls from './urls'
 
 import {
   Bar,
@@ -12,7 +12,7 @@ import {
   Trade,
   TradeUpdate,
   Message,
-} from './entities.js'
+} from './entities'
 
 export declare interface Events {
   open: (stream: AlpacaStream) => void


### PR DESCRIPTION
I'm not 100% sure this is the issue with compilation/transpilation for Jest but seems like a good starting point. I don't believe you can hard code `.js` here and have it work for all scenarios. I know TS and javascript can handle module resolution without the file extension and assuming any build target can handle this resolution.

I had to bring in your project as a git submodule to get my tests working again. FYI - the types and documentation are great!