### PR TITLE
Add getConnection Method to AlpacaStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ The following methods are available on the stream.
 - [subscribe](#subscribe)
 - [unsubscribe](#unsubscribe)
 - [on](#on)
+- [getConnection](#getConnection)
 
 ### Channels
 
@@ -543,6 +544,11 @@ stream.on('bar', (bar) => console.log(bar))
 stream.on('quote', (quote) => console.log(quote))
 stream.on('trade_updates', (update) => console.log(update))
 stream.on('error', (error) => console.warn(error))
+```
+
+#### getConnection
+```typescript
+stream.getConnection()
 ```
 
 ## Examples

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -159,6 +159,16 @@ export class AlpacaStream extends EventEmitter<string | symbol | any> {
   }
 
   /**
+   * Retrieve the underlying WebSocket connection AlpacaStream uses.
+   * Now callers can read and modify properties of the web socket 
+   * i.e., close the websocket with AlpacaStream.getConnection().close().
+   * @returns the of type WebSocket
+   */
+  getConnection() {
+    return this.connection;
+  }
+
+  /**
    * Subscribe to an account or data stream channel.
    * @param channel trades, quotes, bars, trade_updates
    * @param symbols only use with data stream ex. [ "AAPL", "TSLA", ... ]

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -162,7 +162,7 @@ export class AlpacaStream extends EventEmitter<string | symbol | any> {
    * Retrieve the underlying WebSocket connection AlpacaStream uses.
    * Now callers can read and modify properties of the web socket 
    * i.e., close the websocket with AlpacaStream.getConnection().close().
-   * @returns the of type WebSocket
+   * @returns a WebSocket object
    */
   getConnection() {
     return this.connection;


### PR DESCRIPTION
This PR allows the underlying web socket to be retrieved. This allows the caller more control over the stream they have open with Alpaca.