### PR TITLE
Alpaca Stream: Parse Trade Updates Channel

### DIFF
--- a/src/entities.ts
+++ b/src/entities.ts
@@ -1676,12 +1676,107 @@ export type RawActivity = RawTradeActivity | RawNonTradeActivity
 
 export type Activity = TradeActivity | NonTradeActivity
 
-export interface TradeUpdate {
-  event: string
-  price: string
-  timestamp: string
-  position_qty: string
+/**
+ * The following type mirrors OrderStatus almost exactly,
+ * but differs slightly in its wording for each event.
+ * See https://alpaca.markets/docs/api-references/broker-api/events/#trade-events
+ * for an updated list of these events and their detailed descriptions.
+ */
+export type TradeUpdateEvent = 
+  | 'new'
+  | 'fill'
+  | 'partial_fill'
+  | 'canceled'
+  | 'expired'
+  | 'done_for_day'
+  | 'replaced'
+  | 'rejected'
+  | 'pending_new'
+  | 'stopped'
+  | 'pending_cancel'
+  | 'pending_replace'
+  | 'calculated'
+  | 'suspended'
+  | 'order_replace_rejected'
+  | 'order_cancel_rejected'
+;
+
+export interface RawTradeUpdate {
+  event: TradeUpdateEvent
+  execution_id: string
   order: RawOrder
+  event_id?: string
+  at?: string
+  timestamp?: string
+  position_qty?: string
+  price?: string
+  qty?: string
+}
+
+export interface TradeUpdate {
+  /**
+   * Get the raw data, exactly as it came from Alpaca
+   */
+  raw: () => RawTradeUpdate
+
+  /**
+   * Trade update event type
+   */
+  event: TradeUpdateEvent
+
+  /**
+   * Corresponding execution of an order. 
+   * If an order gets filled over two executions (a partial_fill for example), 
+   * you will receive two events with different IDs.
+   */
+  execution_id: string
+
+  /**
+   * Monotonically increasing 64-bit integer.
+   * Haven't yet observed this property in practice, but it is
+   * on Alpaca's docs here: https://alpaca.markets/docs/api-references/broker-api/events/#trade-events,
+   * including for completeness.
+   */
+  event_id?: number
+
+  /**
+   * The associated order that a trade_update event comes with
+   */
+  order: Order
+
+ /** 
+  * The timestamp of the trade update event.
+  * Alpaca docs at https://alpaca.markets/docs/api-references/broker-api/events/#trade-events
+  * are confusing. They say the 'at' property will contain the timestamp of
+  * the event, but currently as of 3/10/22 this is in the 'timestamp' property
+  * instead. Including both for completeness. 
+  */ 
+  at?: Date
+
+  /** 
+  * The timestamp of the trade update event.
+  * Alpaca docs at https://alpaca.markets/docs/api-references/broker-api/events/#trade-events
+  * are confusing. They say the 'at' property will contain the timestamp of
+  * the event, but currently as of 3/10/22 this is in the 'timestamp' property
+  * instead. Including both for completeness. 
+  */ 
+  timestamp?: Date
+  
+  /**
+   * The size of your total position, after a fill or partial fill event, in shares.
+   */
+  position_qty?: number
+
+  /**
+   * The average price per share at which the order was filled or partially filled
+   */
+  price?: number
+
+  /**
+   * The amount of shares that were filled in a trade update of type fill or partial_fill. 
+   * Equivalent to the order.filled_qty property, which is preferred.
+   */
+  qty?: number
 }
 
 export interface Watchlist {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -31,6 +31,8 @@ import {
   PageOfBars,
   Snapshot,
   RawSnapshot,
+  TradeUpdate,
+  RawTradeUpdate
 } from './entities.js'
 
 function account(rawAccount: RawAccount): Account {
@@ -398,6 +400,28 @@ function number(numStr: string | any): number {
   return value
 }
 
+function trade_update(
+  rawTradeUpdate: RawTradeUpdate
+): TradeUpdate {
+
+  if (!rawTradeUpdate) return undefined;
+
+  return {
+    raw: () => rawTradeUpdate,
+    event: rawTradeUpdate.event,
+    execution_id: rawTradeUpdate.execution_id,
+    order: order(rawTradeUpdate.order),
+    
+    /* Only include the non-obligatory fields if they exist */ 
+    ... rawTradeUpdate.event_id &&  { event_id: number(rawTradeUpdate.event_id) },
+    ... rawTradeUpdate.at && { at: new Date(rawTradeUpdate.at) },
+    ... rawTradeUpdate.timestamp && { timestamp: new Date(rawTradeUpdate.timestamp) },
+    ... rawTradeUpdate.position_qty && { position_qty: number(rawTradeUpdate.position_qty) },
+    ... rawTradeUpdate.price && { price: number(rawTradeUpdate.price) },
+    ... rawTradeUpdate.qty && { qty: number(rawTradeUpdate.qty) }
+  }
+}
+
 export default {
   account,
   activities,
@@ -414,4 +438,5 @@ export default {
   pageOfBars,
   snapshot,
   snapshots,
+  trade_update
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3,6 +3,8 @@ import EventEmitter from 'eventemitter3'
 import isBlob from 'is-blob'
 import urls from './urls.js'
 
+import parse from './parse.js';
+
 import {
   Bar,
   Channel,
@@ -133,7 +135,7 @@ export class AlpacaStream extends EventEmitter<string | symbol | any> {
 
         // pass trade_updates event
         if ('stream' in message && message.stream == 'trade_updates') {
-          this.emit('trade_updates', message.data)
+          this.emit('trade_updates', parse.trade_update(message.data))
         }
 
         // pass trade, quote, bar event

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -8,6 +8,7 @@ import {
   RawNonTradeActivity,
   TradeActivity,
   NonTradeActivity,
+  RawTradeUpdate
 } from '../src/entities'
 
 describe('Parser', () => {
@@ -219,5 +220,42 @@ describe('Parser', () => {
       expect((activities[0] as TradeActivity).price).toBe(6.66)
       expect((activities[1] as NonTradeActivity).net_amount).toBe(123.45)
     })
+  })
+
+  describe('parseTradeUpdate', () => {
+    it('should handle missing input', () => {
+      const result = parse.trade_update(null)
+      expect(result).toBeUndefined()
+    })
+
+    it('should parse each portion of a trade update, including inner order', () => {
+
+      /* Setup */
+      const dateIsoString = '2022-03-01T00:00:00.000000000Z'
+      const rawTradeUpdate = {
+        event: 'new',
+        execution_id: 'some-long-hex-string',
+        order: { qty: '1' } as RawOrder,
+        event_id: '123456',
+        at: dateIsoString,
+        timestamp: dateIsoString,
+        position_qty: '0',
+        price: '100.00',
+        qty: '1'
+      } as RawTradeUpdate;
+
+      const result = parse.trade_update(rawTradeUpdate);
+
+      /* Assertions */
+      expect(result.raw()).toBe(rawTradeUpdate);
+      expect(result.execution_id).toBe('some-long-hex-string');
+      expect(result.order.qty).toBe(1);
+      expect(result.event_id).toBe(123456);
+      expect(result.position_qty).toBe(0);
+      expect(result.at).toEqual(new Date(dateIsoString));
+      expect(result.timestamp).toEqual(new Date(dateIsoString))
+      expect(result.price).toBe(100.00);
+      expect(result.qty).toBe(1);
+    });
   })
 })


### PR DESCRIPTION
Thought I'd parse the Trade Updates channel coming back from the Alpaca Stream, for my own benefit and any dev after me who might find it useful! Let me know if this was by design or something. But I tested locally and everything seems to be working 🙂

Side note no. 1: I'll begin unit testing my stuff! Starting with this PR, haha!
Side note no. 2: Sorry about all my commits compounding in my previous PRs, forgot to add this repo as an upstream to my fork.
